### PR TITLE
Remove the API discovery which cause memcache error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # app-engine-start-vm
 Use App Engine to start a Compute Engine VM
+
+## Instruction
+
+1. You have to manually create the VM instance before.
+2. After VM is started, you can press the `STOP` button to stop the VM.
+3. Install the packages with `pip -r requirements.txt -t lib`.
+4. Deploy the app with command `gcloud app deploy app.yaml --version THE_VERSION` or `appcfg.py update app.yaml`.
+5. Visit `/vm/start` to start the VM.

--- a/main.py
+++ b/main.py
@@ -13,20 +13,43 @@ INSTANCE_NAME = 'vm-instance'
 INSTANCE_ZONE = 'us-central1-c'
 PROJECT = 'positive-shell-160220'
 
+def get_http():
+    credentials = AppAssertionCredentials(scope='https://www.googleapis.com/auth/compute')
+    http = credentials.authorize(httplib2.Http(memcache))
+    return http
+
 
 @app.route('/')
 def hello_world():
     return 'Hello World!'
 
 
+@app.route('/vm/get')
+def get_vm():
+    http = get_http()
+    uri = 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{instance}'
+    uri = uri.format(project=PROJECT, zone=INSTANCE_ZONE, instance=INSTANCE_NAME)
+    resp, result = http.request(
+        uri=uri,
+        method='GET'
+        )
+    logging.debug(resp)
+    logging.debug(result)
+    return result, 200, {'Content-Type': 'application/json'}
+
+
 @app.route('/vm/start')
 def start_vm():
-    credentials = AppAssertionCredentials(scope='https://www.googleapis.com/auth/compute')
-    http = credentials.authorize(httplib2.Http(memcache))
-    compute = discovery.build('compute', 'v1', http=http)
-    result = compute.instances().start(instance=INSTANCE_NAME, zone=INSTANCE_ZONE, project=PROJECT).execute()
+    http = get_http()
+    uri = 'https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{instance}/start'
+    uri = uri.format(project=PROJECT, zone=INSTANCE_ZONE, instance=INSTANCE_NAME)
+    resp, result = http.request(
+        uri=uri,
+        method='POST'
+        )
+    logging.debug(resp)
     logging.debug(result)
-    return json.dumps(result, indent=4)
+    return result, 200, {'Content-Type': 'application/json'}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Got this error with the memcache and API discovery:

`ValueError: Values may not be more than 1000000 bytes in length; received 1014324 bytes`

I personally encountered so many problem with the "memcache + discovery.build()" combo. I know it is from the Google example, but it is not so useful after all.

Also added some instructions in README